### PR TITLE
Feature/filter PR

### DIFF
--- a/src/main/java/com/lisaanna/ws_todo/controller/TaskController.java
+++ b/src/main/java/com/lisaanna/ws_todo/controller/TaskController.java
@@ -48,8 +48,16 @@ public class TaskController {
         return ResponseEntity.notFound().build();
     }
 
-    // get filtered
-    //@GetMapping
+    @GetMapping("/{tags}")
+    public ResponseEntity<List<TaskDTO>> findByTags(@PathVariable String tags) {
+        List<TaskDTO> taskByTags = taskService.findTaskByTag(tags);
+
+        if (taskByTags.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok().body(taskByTags);
+    }
 
     // create new
     @PostMapping("/new")

--- a/src/main/java/com/lisaanna/ws_todo/repository/TaskRepository.java
+++ b/src/main/java/com/lisaanna/ws_todo/repository/TaskRepository.java
@@ -2,9 +2,14 @@ package com.lisaanna.ws_todo.repository;
 
 import com.lisaanna.ws_todo.entity.Task;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TaskRepository extends MongoRepository<Task, String> {
     Optional<Task> findByName(String name);
+
+    @Query("{'completed': false}")
+    List<Task> findByNotCompleted();
 }

--- a/src/main/java/com/lisaanna/ws_todo/repository/TaskRepository.java
+++ b/src/main/java/com/lisaanna/ws_todo/repository/TaskRepository.java
@@ -8,8 +8,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TaskRepository extends MongoRepository<Task, String> {
+
     Optional<Task> findByName(String name);
 
     @Query("{'completed': false}")
     List<Task> findByNotCompleted();
+
+    @Query("{'tags': ?0}")
+    List<Task> findByTags(String tags);
+
 }

--- a/src/main/java/com/lisaanna/ws_todo/service/TaskService.java
+++ b/src/main/java/com/lisaanna/ws_todo/service/TaskService.java
@@ -6,7 +6,6 @@ import com.lisaanna.ws_todo.repository.TaskRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -26,7 +25,6 @@ public class TaskService {
 
     // get - auto filtered
     public List<TaskDTO> findNotCompleted() {
-
         return taskRepository.findByNotCompleted().stream().map(taskMapper::mapToTaskDTO).collect(Collectors.toList());
     }
 
@@ -42,9 +40,10 @@ public class TaskService {
         return foundTask.map(taskMapper::mapToTaskDTO);
     }
 
-
-    // get - filtered by input
-    // TODO: Use queries in repo for specified filters
+    // get - by tags
+    public List<TaskDTO> findTaskByTag(String tag) {
+        return taskRepository.findByTags(tag).stream().map(taskMapper::mapToTaskDTO).collect(Collectors.toList());
+    }
 
     // post
     public TaskDTO saveNewTask(TaskDTO taskDTO) {

--- a/src/main/java/com/lisaanna/ws_todo/service/TaskService.java
+++ b/src/main/java/com/lisaanna/ws_todo/service/TaskService.java
@@ -26,15 +26,8 @@ public class TaskService {
 
     // get - auto filtered
     public List<TaskDTO> findNotCompleted() {
-        List<Task> notCompleted = new ArrayList<>();
 
-        for (Task task : taskRepository.findAll()) {
-            if (!task.getCompleted()) {
-                notCompleted.add(task);
-            }
-        }
-
-        return notCompleted.stream().map(taskMapper::mapToTaskDTO).collect(Collectors.toList());
+        return taskRepository.findByNotCompleted().stream().map(taskMapper::mapToTaskDTO).collect(Collectors.toList());
     }
 
     // get - all


### PR DESCRIPTION
Finding uncompleted tasks now uses Query annotation in repository to only fetch uncompleted tasks from collection. This made the code for filtering obsolete and the method findNotCompleted() in service is now a one-liner.

```java
public List<TaskDTO> findNotCompleted() {
    return taskRepository.findByNotCompleted().stream().map(taskMapper::mapToTaskDTO).collect(Collectors.toList());
}
```

Added method for filtering tasks by 'tag'. Thinking we might want to filter based on multiple tags so this one should be looked at again and discussed.

TaskRepository.java:
```java
@Query("{'tags': ?0}")
List<Task> findByTags(String tags);
```

TaskService.java:
```java
public List<TaskDTO> findTaskByTag(String tag) {
    return taskRepository.findByTags(tag).stream().map(taskMapper::mapToTaskDTO).collect(Collectors.toList());
}
```

